### PR TITLE
Use cloud basePath for API clients from configuration passed in

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { Configuration, FetchAPI } from "./runtime";
 import { EventStream } from "./event_stream";
-import { FalconCloud } from "./FalconCloud";
+import { FalconCloud, CloudBasePath } from "./FalconCloud";
 import { OAuth2, UserAgent } from "./middleware";
 import {
     AlertsApi,
@@ -144,6 +144,7 @@ export class FalconClient {
             fetchApi: options.fetchApi,
             accessToken: oauth2.accessToken.bind(oauth2),
             middleware: [new UserAgent()],
+            basePath: CloudBasePath(options.cloud),
         });
         this.alerts = new AlertsApi(this.config);
         this.cloudConnectAws = new CloudConnectAwsApi(this.config);


### PR DESCRIPTION
The API clients aren't using the same basePath derived from the cloud passed in via the client configuration. The causes all requests to fail if the same domain isn't being used for auth.

This passes in the basePath for API clients that is derived from the cloud configuration, keeping the auth and request contexts in sync

#191 