### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "crowdstrike-falcon",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "crowdstrike-falcon",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "crowdstrike-falcon",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "description": "CrowdStrike Falcon SDK for browser and node",
     "sideEffects": false,
     "devDependencies": {

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION=0.6.0 # Target version of FalconJS
+VERSION=0.7.0 # Target version of FalconJS
 
 ORIGINAL_SWAGGER=./specs/swagger.json
 FINAL_SWAGGER=./specs/final.json

--- a/src/middleware/useragent.ts
+++ b/src/middleware/useragent.ts
@@ -8,7 +8,7 @@ export class UserAgent {
                 ...context.init,
                 headers: {
                     ...context.init.headers,
-                    "User-Agent": "falconjs/0.6.0",
+                    "User-Agent": "falconjs/0.7.0",
                 },
             },
         };


### PR DESCRIPTION
Bumps version from 0.6.0 to 0.7.0 across all version-bearing files (`package.json`, `package-lock.json`, `rebuild.sh`, `src/middleware/useragent.ts`).

Since v0.6.0, the most significant change is #323, which switches the QuickScanPro file upload to `multipart/form-data`. This removes the `UploadFileQuickScanProRequest` model and changes the `UploadFileQuickScanPro` method signature, a breaking change for consumers of that endpoint. Per semver pre-1.0 conventions this requires a minor version bump to 0.7.0.

Other changes included in this release: regenerated the codebase against newer swagger specs (#321, #320) and maintenance (#319).