### PR TITLE
ci: bump release workflow to Node 22 for npm@latest compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
 
       # Ensure npm 11.5.1 or later for trusted publishing


### PR DESCRIPTION
npm@latest (12.x) requires Node >=22; the release workflow ran Node 20 and failed at 'npm install -g npm@latest' with EBADENGINE, so npm publish never ran (v0.7.0 release run failed).